### PR TITLE
Fix frontend startup error by adding missing API client

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,160 @@
+/**
+ * API Client for Diopside backend
+ */
+
+import type {
+  Video,
+  VideosResponse,
+  TagsResponse,
+  VideosByTagResponse,
+  RandomVideosResponse,
+  MemoryThumbnailsResponse,
+  HealthResponse,
+  ApiError,
+} from '@/types/api'
+
+// Default API base URL - can be overridden via environment variable
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
+
+/**
+ * Custom error class for API errors
+ */
+export class ApiClientError extends Error {
+  constructor(
+    message: string,
+    public status?: number,
+    public response?: Response
+  ) {
+    super(message)
+    this.name = 'ApiClientError'
+  }
+}
+
+/**
+ * Generic fetch wrapper with error handling
+ */
+async function apiFetch<T>(endpoint: string, options?: RequestInit): Promise<T> {
+  const url = `${API_BASE_URL}${endpoint}`
+  
+  try {
+    const response = await fetch(url, {
+      headers: {
+        'Content-Type': 'application/json',
+        ...options?.headers,
+      },
+      ...options,
+    })
+
+    if (!response.ok) {
+      let errorMessage = `HTTP ${response.status}: ${response.statusText}`
+      
+      try {
+        const errorData: ApiError = await response.json()
+        errorMessage = errorData.detail || errorMessage
+      } catch {
+        // If we can't parse the error response, use the default message
+      }
+      
+      throw new ApiClientError(errorMessage, response.status, response)
+    }
+
+    return await response.json()
+  } catch (error) {
+    if (error instanceof ApiClientError) {
+      throw error
+    }
+    
+    // Network or other errors
+    throw new ApiClientError(
+      `Failed to fetch ${endpoint}: ${error instanceof Error ? error.message : 'Unknown error'}`
+    )
+  }
+}
+
+/**
+ * API Client class with all endpoint methods
+ */
+export class ApiClient {
+  /**
+   * Get videos by year with pagination
+   */
+  static async getVideosByYear(
+    year: number,
+    limit: number = 50,
+    lastKey?: string
+  ): Promise<VideosResponse> {
+    const params = new URLSearchParams({
+      year: year.toString(),
+      limit: limit.toString(),
+    })
+    
+    if (lastKey) {
+      params.append('last_key', lastKey)
+    }
+    
+    return apiFetch<VideosResponse>(`/api/videos?${params}`)
+  }
+
+  /**
+   * Get hierarchical tag tree
+   */
+  static async getTagTree(): Promise<TagsResponse> {
+    return apiFetch<TagsResponse>('/api/tags')
+  }
+
+  /**
+   * Get videos by tag path
+   */
+  static async getVideosByTag(tagPath: string): Promise<VideosByTagResponse> {
+    const params = new URLSearchParams({
+      path: tagPath,
+    })
+    
+    return apiFetch<VideosByTagResponse>(`/api/videos/by-tag?${params}`)
+  }
+
+  /**
+   * Get random videos
+   */
+  static async getRandomVideos(count: number = 1): Promise<RandomVideosResponse> {
+    const params = new URLSearchParams({
+      count: count.toString(),
+    })
+    
+    return apiFetch<RandomVideosResponse>(`/api/videos/random?${params}`)
+  }
+
+  /**
+   * Get memory game thumbnails
+   */
+  static async getMemoryThumbnails(pairs: number = 8): Promise<MemoryThumbnailsResponse> {
+    const params = new URLSearchParams({
+      pairs: pairs.toString(),
+    })
+    
+    return apiFetch<MemoryThumbnailsResponse>(`/api/videos/memory?${params}`)
+  }
+
+  /**
+   * Get single video by ID
+   */
+  static async getVideoById(videoId: string): Promise<Video> {
+    return apiFetch<Video>(`/api/videos/${encodeURIComponent(videoId)}`)
+  }
+
+  /**
+   * Health check endpoint
+   */
+  static async healthCheck(): Promise<HealthResponse> {
+    return apiFetch<HealthResponse>('/health')
+  }
+
+  /**
+   * Root endpoint
+   */
+  static async getRoot(): Promise<{ message: string; status: string }> {
+    return apiFetch<{ message: string; status: string }>('/')
+  }
+}
+
+export default ApiClient


### PR DESCRIPTION
## Problem
The frontend application was failing to start with the following error:
```
Module not found: Can't resolve '@/lib/api'
```

This was preventing the development server from running and the application from loading properly.

## Solution
Created the missing `@/lib/api` module with a complete `ApiClient` class that includes:

- **All backend endpoint methods**: `getVideosByYear`, `getTagTree`, `getVideosByTag`, `getRandomVideos`, `getMemoryThumbnails`, `getVideoById`
- **Proper error handling**: Custom `ApiClientError` class with status codes and response details
- **TypeScript support**: Full type safety with imported API types
- **Environment configuration**: Configurable API base URL via `NEXT_PUBLIC_API_URL`
- **Consistent API**: Methods match the backend FastAPI endpoints exactly

## Changes Made
- Created `frontend/src/lib/api.ts` with complete API client implementation
- Added proper error handling and TypeScript types
- Ensured compatibility with existing `useApi.ts` hooks
- Used `git add -f` to override `.gitignore` exclusion of `lib/` directory

## Testing
- ✅ Frontend development server starts successfully
- ✅ No module resolution errors
- ✅ Application loads and renders properly
- ✅ TypeScript compilation passes

## Impact
- Resolves the blocking startup issue
- Enables frontend development to continue
- Provides foundation for API integration when backend is available
- Maintains type safety throughout the application

The frontend application now starts successfully and is ready for development and testing.