### PR TITLE
Fix cross-region references for WAF WebACL ARN

### DIFF
--- a/CROSS_REGION_FIX_SUMMARY.md
+++ b/CROSS_REGION_FIX_SUMMARY.md
@@ -1,0 +1,118 @@
+# Cross-Region References Fix Summary
+
+## 問題の概要
+
+CDKのクロスリージョン参照機能が有効化されていなかったため、WAFスタック（us-east-1）からメインスタック（ap-northeast-1）へのWebACL ARN参照が失敗していました。
+
+## 実施した修正
+
+### 1. `app.py` の修正
+
+両スタックに `cross_region_references=True` を追加し、WebACL ARNを直接渡すように変更：
+
+```python
+# WAFスタック
+dev_waf_stack = WafStack(
+    app,
+    "ShirayukiTomoFansiteDevWafStack",
+    environment="dev",
+    env=cdk.Environment(
+        account=app.node.try_get_context("account"),
+        region="us-east-1",
+    ),
+    cross_region_references=True,  # 追加
+    tags={...},
+)
+
+# メインスタック
+dev_stack = DevStack(
+    app,
+    "ShirayukiTomoFansiteDevStack",
+    web_acl_arn=dev_waf_stack.web_acl.attr_arn,  # 直接ARNを渡す
+    env=cdk.Environment(
+        account=app.node.try_get_context("account"),
+        region="ap-northeast-1",
+    ),
+    cross_region_references=True,  # 追加
+    tags={...},
+)
+```
+
+### 2. `base_stack.py` の修正
+
+WebACL ARNの取得ロジックを改善：
+
+```python
+# Get WebACL ARN - use provided ARN directly for cross-region references
+if web_acl_arn is None:
+    # Fallback to SSM Parameter lookup for backward compatibility
+    self.web_acl_arn = ssm.StringParameter.value_for_string_parameter(
+        self,
+        parameter_name=f"/shirayuki-tomo-fansite/{self.env_name}/waf/webacl-arn",
+    )
+else:
+    # Use provided WebACL ARN directly (recommended for cross-region references)
+    self.web_acl_arn = web_acl_arn
+```
+
+### 3. `waf_stack.py` の修正
+
+コンストラクタのドキュメントを更新して `cross_region_references` パラメータに対応：
+
+```python
+def __init__(
+    self,
+    scope: Construct,
+    construct_id: str,
+    environment: str,
+    **kwargs: Any,
+) -> None:
+    """Initialize the WAF stack.
+
+    Args:
+        scope: The scope in which to define this construct
+        construct_id: The scoped construct ID
+        environment: Environment name (dev/prod)
+        **kwargs: Additional keyword arguments (including cross_region_references)
+    """
+    super().__init__(scope, construct_id, **kwargs)
+```
+
+## 動作確認
+
+CDK synthesis が成功し、以下が確認できました：
+
+1. **WAFスタック**: SSM Parameter と CrossRegionExportWriter カスタムリソースが生成
+2. **メインスタック**: ExportsReader カスタムリソースと `{{resolve:ssm:...}}` 動的参照が生成
+3. **CloudFront**: WebACLId が適切にクロスリージョン参照で設定
+
+## 次のステップ
+
+1. Bootstrap スタックを最新版（v21以上）に更新：
+   ```bash
+   cdk bootstrap aws://167545301745/us-east-1 \
+                 aws://167545301745/ap-northeast-1
+   ```
+
+2. WAFスタックを先にデプロイ：
+   ```bash
+   uv run cdk deploy ShirayukiTomoFansiteDevWafStack
+   ```
+
+3. SSM パラメータの存在確認：
+   ```bash
+   aws ssm get-parameter \
+     --name /shirayuki-tomo-fansite/dev/waf/webacl-arn \
+     --region ap-northeast-1
+   ```
+
+4. メインスタックをデプロイ：
+   ```bash
+   uv run cdk deploy ShirayukiTomoFansiteDevStack
+   ```
+
+## 技術的詳細
+
+- CDKの `cross_region_references=True` により、自動的にSSMパラメータとカスタムリソースが生成される
+- 参照側では `{{resolve:ssm:...}}` 動的参照を使用してCloudFormationが実行時に値を取得
+- 従来の手動SSM参照（`ssm.StringParameter.value_for_string_parameter`）はフォールバックとして残存

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -21,6 +21,7 @@ def main() -> None:
             account=app.node.try_get_context("account"),
             region="us-east-1",
         ),
+        cross_region_references=True,  # Enable cross-region references
         tags={
             "Project": "shirayuki-tomo-fansite",
             "Environment": "dev",
@@ -36,6 +37,7 @@ def main() -> None:
             account=app.node.try_get_context("account"),
             region="us-east-1",
         ),
+        cross_region_references=True,  # Enable cross-region references
         tags={
             "Project": "shirayuki-tomo-fansite",
             "Environment": "prod",
@@ -47,11 +49,12 @@ def main() -> None:
     dev_stack = DevStack(
         app,
         "ShirayukiTomoFansiteDevStack",
-        # WebACL ARN will be fetched from SSM Parameter automatically
+        web_acl_arn=dev_waf_stack.web_acl.attr_arn,  # Pass WebACL ARN directly
         env=cdk.Environment(
             account=app.node.try_get_context("account"),
             region="ap-northeast-1",
         ),
+        cross_region_references=True,  # Enable cross-region references
         tags={
             "Project": "shirayuki-tomo-fansite",
             "Environment": "dev",
@@ -64,11 +67,12 @@ def main() -> None:
     prod_stack = ProdStack(
         app,
         "ShirayukiTomoFansiteProdStack",
-        # WebACL ARN will be fetched from SSM Parameter automatically
+        web_acl_arn=prod_waf_stack.web_acl.attr_arn,  # Pass WebACL ARN directly
         env=cdk.Environment(
             account=app.node.try_get_context("account"),
             region="ap-northeast-1",
         ),
+        cross_region_references=True,  # Enable cross-region references
         tags={
             "Project": "shirayuki-tomo-fansite",
             "Environment": "prod",

--- a/infrastructure/stacks/base_stack.py
+++ b/infrastructure/stacks/base_stack.py
@@ -42,13 +42,15 @@ class BaseStack(cdk.Stack):
 
         self.env_name = environment
 
-        # Get WebACL ARN from SSM Parameter if not provided directly
+        # Get WebACL ARN - use provided ARN directly for cross-region references
         if web_acl_arn is None:
+            # Fallback to SSM Parameter lookup for backward compatibility
             self.web_acl_arn = ssm.StringParameter.value_for_string_parameter(
                 self,
                 parameter_name=f"/shirayuki-tomo-fansite/{self.env_name}/waf/webacl-arn",
             )
         else:
+            # Use provided WebACL ARN directly (recommended for cross-region references)
             self.web_acl_arn = web_acl_arn
 
         # Create S3 bucket for static hosting and thumbnails

--- a/infrastructure/stacks/waf_stack.py
+++ b/infrastructure/stacks/waf_stack.py
@@ -23,7 +23,7 @@ class WafStack(cdk.Stack):
             scope: The scope in which to define this construct
             construct_id: The scoped construct ID
             environment: Environment name (dev/prod)
-            **kwargs: Additional keyword arguments
+            **kwargs: Additional keyword arguments (including cross_region_references)
         """
         super().__init__(scope, construct_id, **kwargs)
 


### PR DESCRIPTION
## 概要

CDKのクロスリージョン参照機能を有効化し、WAFスタック（us-east-1）からメインスタック（ap-northeast-1）へのWebACL ARN参照エラーを修正しました。

## 問題

CloudFormationデプロイ時に以下のエラーが発生していました：
```
❌ ShirayukiTomoFansiteDevStack failed: ValidationError: Unable to fetch parameters [/shirayuki-tomo-fansite/dev/waf/webacl-arn] from parameter store for this account.
```

## 原因

1. CDKの `cross_region_references: true` フラグが設定されていない
2. Bootstrap スタックが古いバージョン（v21未満）
3. SSM パラメータの自動作成と動的参照が機能していない

## 修正内容

### 1. `infrastructure/app.py`
- 両スタック（WAF・メイン）に `cross_region_references=True` を追加
- WebACL ARNを直接WAFスタックからメインスタックに渡すように変更

### 2. `infrastructure/stacks/base_stack.py`
- WebACL ARN取得ロジックを改善
- 直接渡されたARNを優先し、SSM参照をフォールバックとして保持

### 3. `infrastructure/stacks/waf_stack.py`
- コンストラクタのドキュメントを更新

## 動作確認

✅ CDK synthesis が成功  
✅ WAFスタックでSSMパラメータとCrossRegionExportWriterが生成  
✅ メインスタックでExportsReaderと動的参照（`{{resolve:ssm:...}}`）が生成  
✅ CloudFrontのWebACLIdが適切に設定  

## 次のステップ

1. **Bootstrap更新**:
   ```bash
   cdk bootstrap aws://167545301745/us-east-1 aws://167545301745/ap-northeast-1
   ```

2. **WAFスタック先行デプロイ**:
   ```bash
   uv run cdk deploy ShirayukiTomoFansiteDevWafStack
   ```

3. **SSMパラメータ確認**:
   ```bash
   aws ssm get-parameter --name /shirayuki-tomo-fansite/dev/waf/webacl-arn --region ap-northeast-1
   ```

4. **メインスタックデプロイ**:
   ```bash
   uv run cdk deploy ShirayukiTomoFansiteDevStack
   ```

## 参考資料

- [AWS CDK Cross-region references](https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk/StackProps.html)
- [CloudFormation dynamic references](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html)
- [CDK Bootstrap guide](https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping.html)

詳細な技術情報は `CROSS_REGION_FIX_SUMMARY.md` をご参照ください。