### PR TITLE
feat: add GitHub Actions workflow for deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Setup Moon
+        uses: moonrepo/setup-moon-action@v1
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ap-northeast-1
+
+      - name: Deploy with Moon
+        run: moon run root:deploy
+
+      - name: Upload cdk.out
+        if: contains(github.event_name, 'push')
+        run: |
+          uuid=`uuidgen`
+          echo ${uuid} > ./uuid
+          stack=`cd package/infra && uv run cdk ls 2>&1 | tr -d "\n"`
+          aws s3 cp ./package/infra/cdk.out/ s3://${CDK_OUT_UPLOAD_BUCKET}/${stack}/${uuid}/ --recursive --exclude "*" --include "*.json"
+          aws s3 cp ./uuid s3://${CDK_OUT_UPLOAD_BUCKET}/${stack}/
+        env:
+          AWS_DEFAULT_REGION: 'ap-northeast-1'
+          CDK_OUT_UPLOAD_BUCKET: ${{ secrets.CDK_OUT_UPLOAD_BUCKET }}


### PR DESCRIPTION
# プルリクエスト: GitHub Actionsデプロイワークフローの追加

## 概要
AWS Lambda/CloudFrontへの自動デプロイメントを実現するGitHub Actionsワークフローを追加しました。mainブランチへのプッシュ時およびmanual dispatchで実行可能です。

## 変更内容
- GitHub Actions workflow (.github/workflows/deploy.yml) を新規作成
- Moon タスクランナーを使用したデプロイメント自動化
- AWS OIDC認証による安全な認証情報管理
- CDK出力アーティファクトのS3アップロード機能

## テスト
- [ ] ユニットテストが通る
- [ ] 統合テストが通る  
- [ ] 手動テストを完了
- [ ] E2Eテストが通る（該当する場合）

## 関連Issues
Closes #

## スクリーンショット・動画
<!-- 該当する場合、変更を説明するスクリーンショットや動画を追加してください -->

## チェックリスト
- [x] コードがプロジェクトの[コーディング規約](../docs/development/coding-standards.md)に従っている
- [x] コードの自己レビューを完了
- [ ] ドキュメントを更新（必要な場合）
- [x] 破壊的変更がない（または破壊的変更が文書化されている）
- [x] [コミットメッセージが規約](../docs/development/commit-guidelines.md)に従っている

## デプロイメント注意事項
- AWS_ROLE_TO_ASSUME と CDK_OUT_UPLOAD_BUCKET のシークレット設定が必要
- ap-northeast-1 リージョンを使用
- Node.js 20, Python 3.12, uv, Moon の環境セットアップを含む

---
<!-- メンテナー向け -->
## レビューチェックリスト
詳細は[レビューチェックリスト](../docs/development/review-checklist.md)を参照

- [ ] コード品質が許容できる
- [ ] テストが適切
- [ ] ドキュメントが更新されている
- [ ] 破壊的変更が許容できる・文書化されている