### PR TITLE
fix: static exportモードでのVideoCardサムネイ   ル表示問題を修正

### DIFF
--- a/package/web/src/components/video/VideoCard.tsx
+++ b/package/web/src/components/video/VideoCard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Card, CardBody, CardFooter, Image, Chip } from '@heroui/react'
+import { Card, CardBody, CardFooter, Chip } from '@heroui/react'
 import { CalendarIcon, TagIcon } from '@heroicons/react/24/outline'
 import type { Video } from '@/types/api'
 
@@ -35,11 +35,11 @@ export function VideoCard({ video, onClick, className }: VideoCardProps) {
     >
       <CardBody className="p-0">
         {video.thumbnail_url ? (
-          <Image
+          <img
             src={video.thumbnail_url}
             alt={video.title}
             className="w-full h-48 object-cover"
-            radius="none"
+            loading="lazy"
           />
         ) : (
           <div className="w-full h-48 bg-gradient-to-br from-purple-400 to-purple-600 flex items-center justify-center">

--- a/package/web/tests/components/VideoCard.integration.test.tsx
+++ b/package/web/tests/components/VideoCard.integration.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * Integration test for VideoCard component
+ * Tests the actual implementation without mocking Hero UI components
+ * This test would fail before the fix and pass after the fix
+ */
+
+import { render, screen } from '@testing-library/react'
+import { VideoCard } from '@/components/video/VideoCard'
+import type { Video } from '@/types/api'
+
+// DO NOT mock Hero UI components - we want to test the actual implementation
+
+describe('VideoCard Integration Tests (Fix Verification)', () => {
+  const mockVideo: Video = {
+    video_id: 'test123',
+    title: 'Test Video Title',
+    tags: ['tag1', 'tag2'],
+    year: 2024,
+    thumbnail_url: 'https://img.youtube.com/vi/test123/maxresdefault.jpg',
+    created_at: '2024-01-15T10:30:00Z',
+  }
+
+  describe('Image rendering implementation', () => {
+    it('should render HTML img element instead of Hero UI Image component', () => {
+      render(<VideoCard video={mockVideo} />)
+
+      // After fix: should find HTML img element
+      const imgElement = screen.getByRole('img')
+      expect(imgElement).toBeInTheDocument()
+      expect(imgElement.tagName).toBe('IMG') // Ensures it's a native HTML img element
+    })
+
+    it('should have loading="lazy" attribute on img element', () => {
+      render(<VideoCard video={mockVideo} />)
+
+      // After fix: HTML img should have loading="lazy"
+      // Before fix: Hero UI Image component wouldn't have this attribute
+      const imgElement = screen.getByRole('img')
+      expect(imgElement).toHaveAttribute('loading', 'lazy')
+    })
+
+    it('should NOT have radius attribute (Hero UI specific)', () => {
+      render(<VideoCard video={mockVideo} />)
+
+      // After fix: HTML img doesn't support radius attribute
+      // Before fix: Hero UI Image would have radius="none"
+      const imgElement = screen.getByRole('img')
+      expect(imgElement).not.toHaveAttribute('radius')
+    })
+
+    it('should have correct src and alt attributes', () => {
+      render(<VideoCard video={mockVideo} />)
+
+      const imgElement = screen.getByRole('img')
+      expect(imgElement).toHaveAttribute('src', mockVideo.thumbnail_url)
+      expect(imgElement).toHaveAttribute('alt', mockVideo.title)
+    })
+
+    it('should have object-cover class for proper image styling', () => {
+      render(<VideoCard video={mockVideo} />)
+
+      const imgElement = screen.getByRole('img')
+      expect(imgElement).toHaveClass('object-cover')
+      expect(imgElement).toHaveClass('w-full')
+      expect(imgElement).toHaveClass('h-48')
+    })
+  })
+
+  describe('Fallback behavior when thumbnail_url is not provided', () => {
+    it('should not render any img element when thumbnail_url is undefined', () => {
+      const videoWithoutThumbnail = { ...mockVideo, thumbnail_url: undefined }
+      render(<VideoCard video={videoWithoutThumbnail} />)
+
+      // Should not find any img element
+      expect(screen.queryByRole('img')).not.toBeInTheDocument()
+
+      // Should find the fallback div with gradient background
+      const fallbackDiv = screen.getByText('Te') // First 2 characters of title
+      expect(fallbackDiv).toBeInTheDocument()
+    })
+
+    it('should not render any img element when thumbnail_url is empty string', () => {
+      const videoWithEmptyThumbnail = { ...mockVideo, thumbnail_url: '' }
+      render(<VideoCard video={videoWithEmptyThumbnail} />)
+
+      expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Performance attributes', () => {
+    it('should have loading="lazy" for better performance', () => {
+      render(<VideoCard video={mockVideo} />)
+
+      const imgElement = screen.getByRole('img')
+      expect(imgElement).toHaveAttribute('loading', 'lazy')
+    })
+
+    it('should not have any Next.js Image specific attributes', () => {
+      render(<VideoCard video={mockVideo} />)
+
+      const imgElement = screen.getByRole('img')
+
+      // These are Next.js Image specific attributes that should not be present
+      expect(imgElement).not.toHaveAttribute('priority')
+      expect(imgElement).not.toHaveAttribute('placeholder')
+      expect(imgElement).not.toHaveAttribute('blurDataURL')
+      expect(imgElement).not.toHaveAttribute('unoptimized')
+    })
+  })
+
+  describe('Static export compatibility', () => {
+    it('should use regular img element that works with static export', () => {
+      render(<VideoCard video={mockVideo} />)
+
+      const imgElement = screen.getByRole('img')
+
+      // Verify it's a regular HTML img element, not a Next.js Image
+      expect(imgElement.tagName).toBe('IMG')
+
+      // Should have the YouTube thumbnail URL directly
+      expect(imgElement.getAttribute('src')).toBe(mockVideo.thumbnail_url)
+
+      // Should not have any data-nimg attributes (Next.js Image specific)
+      expect(imgElement).not.toHaveAttribute('data-nimg')
+    })
+
+    it('should handle external URLs correctly', () => {
+      const videoWithExternalUrl = {
+        ...mockVideo,
+        thumbnail_url: 'https://external-cdn.example.com/thumbnail.jpg'
+      }
+      render(<VideoCard video={videoWithExternalUrl} />)
+
+      const imgElement = screen.getByRole('img')
+      expect(imgElement.getAttribute('src')).toBe(videoWithExternalUrl.thumbnail_url)
+    })
+  })
+})
+
+/**
+ * Test cases that would specifically fail BEFORE the fix:
+ *
+ * 1. 'should have loading="lazy" attribute' - Would fail because Hero UI Image doesn't have this attribute
+ * 2. 'should NOT have radius attribute' - Would fail because Hero UI Image would have radius="none"
+ * 3. 'should use regular img element' - Would fail because Hero UI Image renders different elements
+ * 4. 'should not have data-nimg attributes' - Would fail if using Next.js Image component
+ *
+ * These tests verify that we're using plain HTML img elements with appropriate attributes
+ * for static export mode, which is essential for proper image display in production.
+ */

--- a/package/web/tests/components/VideoCard.test.tsx
+++ b/package/web/tests/components/VideoCard.test.tsx
@@ -22,9 +22,6 @@ jest.mock('@heroui/react', () => ({
       {children}
     </div>
   ),
-  Image: ({ src, alt, ...props }: any) => (
-    <img src={src} alt={alt} data-testid="video-thumbnail" {...props} />
-  ),
   Chip: ({ children, ...props }: any) => (
     <span data-testid="chip" {...props}>
       {children}
@@ -54,8 +51,9 @@ describe('VideoCard', () => {
     expect(screen.getByText('Test Video Title')).toBeInTheDocument()
     expect(screen.getByText('2024年')).toBeInTheDocument()
     expect(screen.getByText('2024/1/15')).toBeInTheDocument()
-    expect(screen.getByTestId('video-thumbnail')).toHaveAttribute('src', mockVideo.thumbnail_url)
-    expect(screen.getByTestId('video-thumbnail')).toHaveAttribute('alt', mockVideo.title)
+    const imgElement = screen.getByRole('img')
+    expect(imgElement).toHaveAttribute('src', mockVideo.thumbnail_url)
+    expect(imgElement).toHaveAttribute('alt', mockVideo.title)
   })
 
   it('renders tags correctly', () => {
@@ -71,7 +69,7 @@ describe('VideoCard', () => {
     const videoWithoutThumbnail = { ...mockVideo, thumbnail_url: undefined }
     render(<VideoCard video={videoWithoutThumbnail} />)
 
-    expect(screen.queryByTestId('video-thumbnail')).not.toBeInTheDocument()
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
     expect(screen.getByText('Te')).toBeInTheDocument() // First 2 characters of title
   })
 


### PR DESCRIPTION
# プルリクエスト

## 概要
メインページ、タグ検索ページ、ランダムページでサムネイル画像が表示されない問題を修正しました。

## 変更内容
- VideoCardコンポーネントでHero UIの`Image`コンポーネントをHTML標準の`<img>`要素に置き換え
- `loading="lazy"`属性を追加してパフォーマンスを最適化
- Next.jsのstatic exportモードとの互換性を確保

## 問題の原因
Next.jsのstatic exportモード（`output: 'export'`）では画像の最適化が無効化されているため、Hero UIの`Image`コンポーネントが外部画像URLを正しく処理できていませんでした。

## 解決方法
```tsx
// Before (問題のあるコード)
<Image
  src={video.thumbnail_url}
  alt={video.title}
  className="w-full h-48 object-cover"
  radius="none"
/>

// After (修正後)
<img
  src={video.thumbnail_url}
  alt={video.title}
  className="w-full h-48 object-cover"
  loading="lazy"
/>
```

## テスト
- [x] ユニットテストが通る
- [x] 統合テストが通る（新規作成）
- [x] 手動テストを完了
- [ ] E2Eテストが通る（該当する場合）

### テスト内容
1. **新規統合テスト（VideoCard.integration.test.tsx）**
   - 修正前のコードでは2つのテストが失敗（`loading="lazy"`属性の不在）
   - 修正後のコードではすべてのテスト（11件）が成功

2. **既存テストの互換性**
   - VideoCard.test.tsxを更新して、新しい実装と互換性を保持
   - すべてのテスト（12件）が成功

## 関連Issues
<!-- 関連するissueをリンクしてください -->
Closes #

## 変更前後の動作

### 変更前
- Hero UI `Image`コンポーネントを使用
- static exportモードで外部画像URLが正しく表示されない
- `loading="lazy"`属性なし

### 変更後
- HTML標準の`<img>`要素を使用
- 外部画像URL（YouTube、CloudFront等）が正しく表示される
- `loading="lazy"`でパフォーマンス最適化

## チェックリスト
- [x] コードがプロジェクトの[コーディング規約](../docs/development/coding-standards.md)に従っている
- [x] コードの自己レビューを完了
- [ ] ドキュメントを更新（必要な場合）
- [x] 破壊的変更がない（または破壊的変更が文書化されている）
- [x] [コミットメッセージが規約](../docs/development/commit-guidelines.md)に従っている

## デプロイメント注意事項
- この修正はstatic exportモードでの画像表示に必要な変更です
- CloudFront + S3でのホスティング環境で正しく動作することを確認済み
- 既存のAPIレスポンスとの互換性は維持されます

## 技術的詳細

### 修正ファイル
- `package/web/src/components/video/VideoCard.tsx`
  - Hero UI `Image` → HTML `<img>`への変更
  - `loading="lazy"`属性の追加

### テストファイル
- `package/web/tests/components/VideoCard.test.tsx`（更新）
  - `getByTestId` → `getByRole('img')`への変更
- `package/web/tests/components/VideoCard.integration.test.tsx`（新規）
  - 修正前後の動作を検証する統合テスト

### 影響範囲
- メインページ（`/`）の動画グリッド表示
- タグページ（`/tags`）の動画一覧
- ランダムページ（`/random`）の動画表示
- メモリーゲーム（`/memory`）は既に`<img>`要素を使用しているため影響なし

---
<!-- メンテナー向け -->
## レビューチェックリスト
詳細は[レビューチェックリスト](../docs/development/review-checklist.md)を参照

- [ ] コード品質が許容できる
- [ ] テストが適切
- [ ] ドキュメントが更新されている
- [ ] 破壊的変更が許容できる・文書化されている